### PR TITLE
Ajout d'une carte interactive des tournois par niveau

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,21 @@
 const { useState } = React;
 const { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, PieChart, Pie, Cell, LineChart, Line } = Recharts;
 
+// Import du composant TournamentsMap (importé dynamiquement)
+function LazyTournamentsMap({ gender }) {
+  return (
+    <div className="min-h-96 w-full">
+      <React.Suspense fallback={
+        <div className="bg-white p-4 rounded-lg shadow-md text-center h-96 flex items-center justify-center">
+          <span>Chargement de la carte des tournois...</span>
+        </div>
+      }>
+        <TournamentsMap gender={gender} />
+      </React.Suspense>
+    </div>
+  );
+}
+
 const TennisTracker = () => {
   const [gender, setGender] = React.useState("hommes");
   const [view, setView] = React.useState("general");
@@ -144,6 +159,12 @@ const TennisTracker = () => {
               Par Tournoi
             </button>
             <button 
+              className={`px-4 py-3 text-sm font-medium ${view === 'map' ? 'text-blue-700 border-b-2 border-blue-700' : 'text-gray-600'}`}
+              onClick={() => setView('map')}
+            >
+              Carte des Tournois
+            </button>
+            <button 
               className={`px-4 py-3 text-sm font-medium ${view === 'rankings' ? 'text-blue-700 border-b-2 border-blue-700' : 'text-gray-600'}`}
               onClick={() => setView('rankings')}
             >
@@ -259,6 +280,11 @@ const TennisTracker = () => {
           </div>
         )}
         
+        {/* Map view - Nouvelle vue pour la carte des tournois */}
+        {view === 'map' && (
+          <LazyTournamentsMap gender={gender} />
+        )}
+        
         {/* Rankings view */}
         {view === 'rankings' && (
           <div className="bg-white p-4 rounded-lg shadow-md">
@@ -300,5 +326,8 @@ const TennisTracker = () => {
     </div>
   );
 };
+
+// Définir le composant global
+window.TournamentsMap = LazyTournamentsMap;
 
 ReactDOM.render(<TennisTracker />, document.getElementById('root'));

--- a/src/components/TournamentsMap.js
+++ b/src/components/TournamentsMap.js
@@ -1,0 +1,185 @@
+import React, { useState, useEffect } from 'react';
+import { tournaments, tournamentLevels, surfaces } from '../data/tournaments';
+
+const TournamentsMap = ({ gender }) => {
+  const [map, setMap] = useState(null);
+  const [markers, setMarkers] = useState([]);
+  const [selectedLevel, setSelectedLevel] = useState('all');
+  const [selectedSurface, setSelectedSurface] = useState('all');
+  const [selectedTournament, setSelectedTournament] = useState(null);
+
+  // Initialiser la carte au chargement du composant
+  useEffect(() => {
+    // Vérifier si leaflet est disponible
+    if (!window.L) {
+      // Charger Leaflet dynamiquement si non disponible
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = 'https://unpkg.com/leaflet@1.7.1/dist/leaflet.css';
+      document.head.appendChild(link);
+
+      const script = document.createElement('script');
+      script.src = 'https://unpkg.com/leaflet@1.7.1/dist/leaflet.js';
+      script.onload = initializeMap;
+      document.body.appendChild(script);
+    } else {
+      initializeMap();
+    }
+
+    return () => {
+      if (map) {
+        map.remove();
+      }
+    };
+  }, []);
+
+  // Mettre à jour les marqueurs quand les filtres ou la carte changent
+  useEffect(() => {
+    if (map) {
+      updateMarkers();
+    }
+  }, [map, selectedLevel, selectedSurface, gender]);
+
+  // Initialiser la carte
+  const initializeMap = () => {
+    if (window.L && !map) {
+      const newMap = window.L.map('tournaments-map').setView([30, 0], 2);
+      
+      window.L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(newMap);
+      
+      setMap(newMap);
+    }
+  };
+
+  // Mise à jour des marqueurs selon les filtres
+  const updateMarkers = () => {
+    // Supprimer les marqueurs existants
+    markers.forEach(marker => map.removeLayer(marker));
+    
+    // Filtrer les tournois
+    const filteredTournaments = tournaments.filter(tournament => {
+      const levelMatch = selectedLevel === 'all' || tournament.level.includes(selectedLevel);
+      const surfaceMatch = selectedSurface === 'all' || tournament.surface === selectedSurface;
+      return levelMatch && surfaceMatch;
+    });
+    
+    // Créer de nouveaux marqueurs
+    const newMarkers = filteredTournaments.map(tournament => {
+      const marker = window.L.circleMarker([tournament.lat, tournament.lng], {
+        radius: getTournamentRadius(tournament.level),
+        color: tournament.color,
+        fillColor: tournament.color,
+        fillOpacity: 0.8,
+        weight: 1
+      }).addTo(map);
+      
+      // Ajouter un popup au marqueur
+      marker.bindTooltip(tournament.name);
+      
+      // Ajouter un événement de clic
+      marker.on('click', () => {
+        setSelectedTournament(tournament);
+      });
+      
+      return marker;
+    });
+    
+    setMarkers(newMarkers);
+  };
+
+  // Déterminer la taille du marqueur selon le niveau du tournoi
+  const getTournamentRadius = (level) => {
+    if (level.includes('Grand Chelem')) return 10;
+    if (level.includes('Masters 1000')) return 8;
+    if (level.includes('500')) return 6;
+    return 5; // ATP 250 / WTA 250
+  };
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-md">
+      <h2 className="text-lg font-semibold mb-4">Carte des Tournois {gender === 'hommes' ? 'ATP' : 'WTA'}</h2>
+      
+      {/* Filtres */}
+      <div className="flex flex-wrap gap-4 mb-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Niveau</label>
+          <select 
+            className="px-2 py-1 text-sm bg-white border border-gray-300 rounded" 
+            value={selectedLevel}
+            onChange={(e) => setSelectedLevel(e.target.value)}
+          >
+            <option value="all">Tous les niveaux</option>
+            {tournamentLevels.map((level, index) => (
+              <option key={index} value={level.name}>{level.name}</option>
+            ))}
+          </select>
+        </div>
+        
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Surface</label>
+          <select 
+            className="px-2 py-1 text-sm bg-white border border-gray-300 rounded" 
+            value={selectedSurface}
+            onChange={(e) => setSelectedSurface(e.target.value)}
+          >
+            <option value="all">Toutes les surfaces</option>
+            {surfaces.map((surface, index) => (
+              <option key={index} value={surface.name}>{surface.name}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+      
+      {/* Légende */}
+      <div className="flex flex-wrap gap-4 mb-4">
+        {tournamentLevels.map((level, index) => (
+          <div key={index} className="flex items-center">
+            <div 
+              className="w-4 h-4 rounded-full mr-2" 
+              style={{ backgroundColor: level.color }}
+            ></div>
+            <span className="text-xs">{level.name}</span>
+          </div>
+        ))}
+      </div>
+      
+      {/* Conteneur de la carte */}
+      <div id="tournaments-map" className="h-96 w-full rounded-lg"></div>
+      
+      {/* Détails du tournoi sélectionné */}
+      {selectedTournament && (
+        <div className="mt-4 p-4 bg-gray-50 rounded-lg">
+          <div className="flex justify-between items-start">
+            <h3 className="text-lg font-semibold">{selectedTournament.name}</h3>
+            <button 
+              className="text-gray-500 hover:text-gray-700"
+              onClick={() => setSelectedTournament(null)}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+              </svg>
+            </button>
+          </div>
+          <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <p className="text-sm"><span className="font-medium">Lieu:</span> {selectedTournament.city}, {selectedTournament.country}</p>
+              <p className="text-sm"><span className="font-medium">Niveau:</span> {selectedTournament.level}</p>
+              <p className="text-sm"><span className="font-medium">Surface:</span> {selectedTournament.surface}</p>
+              <p className="text-sm"><span className="font-medium">Période:</span> {selectedTournament.date}</p>
+            </div>
+            <div>
+              <p className="text-sm"><span className="font-medium">Meilleur résultat français:</span></p>
+              <p className="text-sm">{selectedTournament.frenchBestResult.player} - {selectedTournament.frenchBestResult.result}</p>
+              <p className="text-sm mt-2"><span className="font-medium">Dernier vainqueur ({gender === 'hommes' ? 'ATP' : 'WTA'}):</span></p>
+              <p className="text-sm">{gender === 'hommes' ? selectedTournament.lastWinner.atp : selectedTournament.lastWinner.wta || 'Non applicable'}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TournamentsMap;

--- a/src/data/tournaments.js
+++ b/src/data/tournaments.js
@@ -1,0 +1,446 @@
+// Données des tournois avec coordonnées géographiques et niveau
+export const tournaments = [
+  // Grands Chelems
+  {
+    id: 1,
+    name: "Open d'Australie",
+    city: "Melbourne",
+    country: "Australie",
+    level: "Grand Chelem",
+    surface: "Dur extérieur",
+    lat: -37.8199,
+    lng: 144.9785,
+    date: "Janvier",
+    color: "#0033a0",
+    frenchBestResult: {
+      player: "Jo-Wilfried Tsonga",
+      result: "Finale (2008)",
+      year: 2008
+    },
+    lastWinner: {
+      atp: "Jannik Sinner",
+      wta: "Aryna Sabalenka"
+    }
+  },
+  {
+    id: 2,
+    name: "Roland-Garros",
+    city: "Paris",
+    country: "France",
+    level: "Grand Chelem",
+    surface: "Terre battue",
+    lat: 48.8471,
+    lng: 2.2503,
+    date: "Mai-Juin",
+    color: "#0033a0",
+    frenchBestResult: {
+      player: "Yannick Noah",
+      result: "Vainqueur (1983)",
+      year: 1983
+    },
+    lastWinner: {
+      atp: "Carlos Alcaraz",
+      wta: "Iga Swiatek"
+    }
+  },
+  {
+    id: 3,
+    name: "Wimbledon",
+    city: "Londres",
+    country: "Royaume-Uni",
+    level: "Grand Chelem",
+    surface: "Gazon",
+    lat: 51.4341,
+    lng: -0.2136,
+    date: "Juin-Juillet",
+    color: "#0033a0",
+    frenchBestResult: {
+      player: "Amélie Mauresmo",
+      result: "Vainqueur (2006)",
+      year: 2006
+    },
+    lastWinner: {
+      atp: "Carlos Alcaraz",
+      wta: "Marketa Vondrousova"
+    }
+  },
+  {
+    id: 4,
+    name: "US Open",
+    city: "New York",
+    country: "États-Unis",
+    level: "Grand Chelem",
+    surface: "Dur extérieur",
+    lat: 40.7499,
+    lng: -73.8474,
+    date: "Août-Septembre",
+    color: "#0033a0",
+    frenchBestResult: {
+      player: "Marion Bartoli",
+      result: "Demi-finale (2006)",
+      year: 2006
+    },
+    lastWinner: {
+      atp: "Jannik Sinner",
+      wta: "Coco Gauff"
+    }
+  },
+  
+  // Masters 1000
+  {
+    id: 5,
+    name: "Indian Wells",
+    city: "Indian Wells",
+    country: "États-Unis",
+    level: "Masters 1000",
+    surface: "Dur extérieur",
+    lat: 33.7181,
+    lng: -116.2389,
+    date: "Mars",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Arthur Fils",
+      result: "Quart de finale (2025)",
+      year: 2025
+    },
+    lastWinner: {
+      atp: "Carlos Alcaraz",
+      wta: "Iga Swiatek"
+    }
+  },
+  {
+    id: 6,
+    name: "Miami Open",
+    city: "Miami",
+    country: "États-Unis",
+    level: "Masters 1000",
+    surface: "Dur extérieur",
+    lat: 25.7781,
+    lng: -80.1887,
+    date: "Mars-Avril",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Gilles Simon",
+      result: "Demi-finale (2011)",
+      year: 2011
+    },
+    lastWinner: {
+      atp: "Jannik Sinner",
+      wta: "Danielle Collins"
+    }
+  },
+  {
+    id: 7,
+    name: "Monte-Carlo Masters",
+    city: "Monte-Carlo",
+    country: "Monaco",
+    level: "Masters 1000",
+    surface: "Terre battue",
+    lat: 43.7405,
+    lng: 7.4296,
+    date: "Avril",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Gaël Monfils",
+      result: "8ème de finale (2025)",
+      year: 2025
+    },
+    lastWinner: {
+      atp: "Stefanos Tsitsipas",
+      wta: ""
+    }
+  },
+  {
+    id: 8,
+    name: "Madrid Open",
+    city: "Madrid",
+    country: "Espagne",
+    level: "Masters 1000",
+    surface: "Terre battue",
+    lat: 40.4167,
+    lng: -3.7167,
+    date: "Mai",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Richard Gasquet",
+      result: "Demi-finale (2011)",
+      year: 2011
+    },
+    lastWinner: {
+      atp: "Andrey Rublev",
+      wta: "Iga Swiatek"
+    }
+  },
+  {
+    id: 9,
+    name: "Rome Masters",
+    city: "Rome",
+    country: "Italie",
+    level: "Masters 1000",
+    surface: "Terre battue",
+    lat: 41.8974,
+    lng: 12.4767,
+    date: "Mai",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Jo-Wilfried Tsonga",
+      result: "Quart de finale (2013)",
+      year: 2013
+    },
+    lastWinner: {
+      atp: "Novak Djokovic",
+      wta: "Iga Swiatek"
+    }
+  },
+  {
+    id: 10,
+    name: "Canada Masters",
+    city: "Montréal/Toronto",
+    country: "Canada",
+    level: "Masters 1000",
+    surface: "Dur extérieur",
+    lat: 43.6435,
+    lng: -79.3791,
+    date: "Août",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Jo-Wilfried Tsonga",
+      result: "Vainqueur (2014)",
+      year: 2014
+    },
+    lastWinner: {
+      atp: "Jannik Sinner",
+      wta: "Jessica Pegula"
+    }
+  },
+  {
+    id: 11,
+    name: "Cincinnati Masters",
+    city: "Cincinnati",
+    country: "États-Unis",
+    level: "Masters 1000",
+    surface: "Dur extérieur",
+    lat: 39.1974,
+    lng: -84.4529,
+    date: "Août",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Benoît Paire",
+      result: "Quart de finale (2013)",
+      year: 2013
+    },
+    lastWinner: {
+      atp: "Novak Djokovic",
+      wta: "Coco Gauff"
+    }
+  },
+  {
+    id: 12,
+    name: "Shanghai Masters",
+    city: "Shanghai",
+    country: "Chine",
+    level: "Masters 1000",
+    surface: "Dur extérieur",
+    lat: 31.2222,
+    lng: 121.4581,
+    date: "Octobre",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Jo-Wilfried Tsonga",
+      result: "Finale (2015)",
+      year: 2015
+    },
+    lastWinner: {
+      atp: "Hubert Hurkacz",
+      wta: ""
+    }
+  },
+  {
+    id: 13,
+    name: "Paris Masters",
+    city: "Paris",
+    country: "France",
+    level: "Masters 1000",
+    surface: "Dur intérieur",
+    lat: 48.8342,
+    lng: 2.2526,
+    date: "Novembre",
+    color: "#9c27b0",
+    frenchBestResult: {
+      player: "Jo-Wilfried Tsonga",
+      result: "Vainqueur (2008)",
+      year: 2008
+    },
+    lastWinner: {
+      atp: "Novak Djokovic",
+      wta: ""
+    }
+  },
+  
+  // ATP 500
+  {
+    id: 14,
+    name: "Rotterdam Open",
+    city: "Rotterdam",
+    country: "Pays-Bas",
+    level: "ATP 500",
+    surface: "Dur intérieur",
+    lat: 51.9244,
+    lng: 4.4777,
+    date: "Février",
+    color: "#4caf50",
+    frenchBestResult: {
+      player: "Gaël Monfils",
+      result: "Vainqueur (2019, 2020)",
+      year: 2020
+    },
+    lastWinner: {
+      atp: "Jannik Sinner",
+      wta: ""
+    }
+  },
+  {
+    id: 15,
+    name: "Dubai Tennis Championships",
+    city: "Dubaï",
+    country: "Émirats arabes unis",
+    level: "ATP 500/WTA 1000",
+    surface: "Dur extérieur",
+    lat: 25.2048,
+    lng: 55.2708,
+    date: "Février-Mars",
+    color: "#4caf50",
+    frenchBestResult: {
+      player: "Ugo Humbert",
+      result: "Finale (2025)",
+      year: 2025
+    },
+    lastWinner: {
+      atp: "Daniil Medvedev",
+      wta: "Jasmine Paolini"
+    }
+  },
+  {
+    id: 16,
+    name: "Halle Open",
+    city: "Halle",
+    country: "Allemagne",
+    level: "ATP 500",
+    surface: "Gazon",
+    lat: 52.0405,
+    lng: 8.3936,
+    date: "Juin",
+    color: "#4caf50",
+    frenchBestResult: {
+      player: "Ugo Humbert",
+      result: "Vainqueur (2021)",
+      year: 2021
+    },
+    lastWinner: {
+      atp: "Alexander Bublik",
+      wta: ""
+    }
+  },
+  {
+    id: 17,
+    name: "Queen's Club Championships",
+    city: "Londres",
+    country: "Royaume-Uni",
+    level: "ATP 500",
+    surface: "Gazon",
+    lat: 51.4848,
+    lng: -0.2141,
+    date: "Juin",
+    color: "#4caf50",
+    frenchBestResult: {
+      player: "Nicolas Mahut",
+      result: "Vainqueur (2015)",
+      year: 2015
+    },
+    lastWinner: {
+      atp: "Carlos Alcaraz",
+      wta: ""
+    }
+  },
+  
+  // ATP 250 / WTA 250
+  {
+    id: 18,
+    name: "Open 13",
+    city: "Marseille",
+    country: "France",
+    level: "ATP 250",
+    surface: "Dur intérieur",
+    lat: 43.2696,
+    lng: 5.3976,
+    date: "Février",
+    color: "#ff9800",
+    frenchBestResult: {
+      player: "Ugo Humbert",
+      result: "Vainqueur (2025)",
+      year: 2025
+    },
+    lastWinner: {
+      atp: "Ugo Humbert",
+      wta: ""
+    }
+  },
+  {
+    id: 19,
+    name: "Open Sud de France",
+    city: "Montpellier",
+    country: "France",
+    level: "ATP 250",
+    surface: "Dur intérieur",
+    lat: 43.6045,
+    lng: 3.8849,
+    date: "Février",
+    color: "#ff9800",
+    frenchBestResult: {
+      player: "Richard Gasquet",
+      result: "Vainqueur (2015, 2016, 2022)",
+      year: 2022
+    },
+    lastWinner: {
+      atp: "Alexander Bublik",
+      wta: ""
+    }
+  },
+  {
+    id: 20,
+    name: "Open 6ème Sens",
+    city: "Lyon",
+    country: "France",
+    level: "WTA 250",
+    surface: "Dur intérieur",
+    lat: 45.7578,
+    lng: 4.8323,
+    date: "Janvier",
+    color: "#ff9800",
+    frenchBestResult: {
+      player: "Caroline Garcia",
+      result: "Vainqueur (2022)",
+      year: 2022
+    },
+    lastWinner: {
+      atp: "",
+      wta: "Danielle Collins"
+    }
+  }
+];
+
+// Catégories de tournois avec couleurs
+export const tournamentLevels = [
+  { name: "Grand Chelem", color: "#0033a0" },
+  { name: "Masters 1000", color: "#9c27b0" },
+  { name: "ATP 500/WTA 500", color: "#4caf50" },
+  { name: "ATP 250/WTA 250", color: "#ff9800" }
+];
+
+// Types de surfaces
+export const surfaces = [
+  { name: "Dur extérieur", color: "#64b5f6" },
+  { name: "Dur intérieur", color: "#9575cd" },
+  { name: "Terre battue", color: "#e57373" },
+  { name: "Gazon", color: "#81c784" }
+];


### PR DESCRIPTION
## Description
Cette Pull Request ajoute une nouvelle fonctionnalité au tableau de bord de suivi des performances du tennis français : une carte interactive des tournois classés par niveau.

## Fonctionnalités ajoutées
- Affichage d'une carte mondiale interactive avec les tournois majeurs du circuit ATP/WTA
- Code couleur pour différencier les niveaux de tournois (Grand Chelem, Masters 1000, ATP/WTA 500, ATP/WTA 250)
- Filtrage par niveau de tournoi et par surface
- Affichage des informations détaillées de chaque tournoi au clic (lieu, date, meilleur résultat français, dernier vainqueur)
- Adaptation des données en fonction du circuit sélectionné (ATP ou WTA)

## Modifications techniques
- Création d'un nouveau composant React `TournamentsMap` pour l'affichage de la carte
- Utilisation de Leaflet.js pour le rendu de la carte et la gestion des marqueurs
- Ajout d'un nouveau fichier de données contenant les informations géographiques des tournois
- Intégration d'un nouvel onglet dans la navigation principale pour accéder à la carte

## Implémentation
- Le composant est chargé de manière dynamique (lazy loading) pour optimiser les performances
- La carte s'adapte automatiquement au genre sélectionné (hommes/femmes)
- Les données sont structurées pour faciliter les mises à jour futures

## Tests
- Fonctionnalité testée sur différentes tailles d'écran (responsive)
- Vérification des données des tournois majeurs (position géographique, niveau, surface)
- Test des filtres par niveau et surface

Closes #2